### PR TITLE
💚 CI test Update (Target Node 20 -> 20, 22)

### DIFF
--- a/.github/workflows/node.js.test.yml
+++ b/.github/workflows/node.js.test.yml
@@ -16,7 +16,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [ 20.x ]
+        node-version: [ 20.x, 22.x ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     
     steps:


### PR DESCRIPTION
(Node.js LTS 현재 버전이 22로 변경(10.29)에 따라, 테스트 대상 node 버전 확대