### PR TITLE
JYXB-234-FE-Prompt-Detail-Review

### DIFF
--- a/apps/client/src/action/review/getReviewData.ts
+++ b/apps/client/src/action/review/getReviewData.ts
@@ -1,8 +1,8 @@
 import type { PromptReviewType } from "@/types/review/reviewType"
 import { ProductReviewDatas } from "@/dummy/review/productReviewDatas"
 
-export async function getProductReview(): Promise<PromptReviewType[]> {
-	const res: PromptReviewType[] = await ProductReviewDatas
+export async function getProductReview(): Promise<PromptReviewType> {
+	const res: PromptReviewType = await ProductReviewDatas
 	// const res: ProfileMemberInfoType = await profileMemberInfoUndefineData
 
 	//     const res = await fetch(`${process.env.API_BASE_URL}/v1/profile`, {

--- a/apps/client/src/app/prompt-detail/[id]/page.tsx
+++ b/apps/client/src/app/prompt-detail/[id]/page.tsx
@@ -7,7 +7,7 @@ export default async function PromptDetail() {
 	const productReview = await getProductReview()
 
 	return (
-		<main className="flex min-h-screen w-screen justify-center overflow-auto bg-[#111111] py-20">
+		<main className="flex min-h-screen w-screen flex-col justify-center overflow-auto bg-[#111111] p-20">
 			<PromptDetailTemplate
 				productDetail={productDetail}
 				productReview={productReview}

--- a/apps/client/src/components/prompt-detail/atoms/PromptDetailGet.tsx
+++ b/apps/client/src/components/prompt-detail/atoms/PromptDetailGet.tsx
@@ -1,6 +1,6 @@
+import React from "react"
 import { Button } from "@repo/ui/button"
 import { ShoppingBag } from "@repo/ui/lucide"
-import React from "react"
 
 export default function PromptDetailGet() {
 	return (

--- a/apps/client/src/components/prompt-detail/atoms/PromptDetailReviewLine.tsx
+++ b/apps/client/src/components/prompt-detail/atoms/PromptDetailReviewLine.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import React, { useState } from "react"
+import { ArrowDownCircleIcon, ArrowUpCircleIcon } from "@repo/ui/lucide"
+
+interface ReviewLineProps {
+	content: string
+}
+
+export default function PromptDetailReviewLine({ content }: ReviewLineProps) {
+	const [isExpanded, setIsExpanded] = useState(false)
+
+	const toggleReview = () => {
+		setIsExpanded(!isExpanded)
+	}
+
+	return (
+		<div className="mb-4 mt-4 flex gap-2 pl-4 lg:gap-4 lg:pl-20">
+			<div className="flex min-h-[80px] w-[94%] items-center overflow-hidden rounded-lg bg-[#181318]">
+				<p
+					className={`m-3 text-sm font-semibold transition-all duration-500 ease-in-out lg:text-base ${
+						isExpanded
+							? "]max-h-[400px] min-h-[100px]"
+							: "line-clamp-5 min-h-[100px] lg:max-h-16"
+					}`}>
+					<span>{content}</span>
+				</p>
+			</div>
+			<div className="mr-2 flex justify-center">
+				{isExpanded ? (
+					<ArrowUpCircleIcon
+						className="cursor-pointer text-white"
+						onClick={toggleReview}
+					/>
+				) : (
+					<ArrowDownCircleIcon
+						className="cursor-pointer text-white"
+						onClick={toggleReview}
+					/>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/apps/client/src/components/prompt-detail/atoms/PromptDetailSadImoticon.tsx
+++ b/apps/client/src/components/prompt-detail/atoms/PromptDetailSadImoticon.tsx
@@ -1,0 +1,5 @@
+import React from "react"
+
+export default function PromptDetailSadImoticon() {
+	return <span>( -̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥᷄ _ -̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥̥᷅ )</span>
+}

--- a/apps/client/src/components/prompt-detail/molecules/PromptDetailNoReview.tsx
+++ b/apps/client/src/components/prompt-detail/molecules/PromptDetailNoReview.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+import PromptDetailSadImoticon from "../atoms/PromptDetailSadImoticon"
+
+export default function PromptDetailNoReview() {
+	return (
+		<div className="item-center mr-4 flex h-[80px] items-center justify-center rounded-md bg-[#1b1b1b] text-center">
+			<p className="flex items-center gap-3 text-base">
+				<span className="font-bold">리뷰가 없습니다</span>
+				<PromptDetailSadImoticon />
+			</p>
+		</div>
+	)
+}

--- a/apps/client/src/components/prompt-detail/molecules/PromptDetailProductDescription.tsx
+++ b/apps/client/src/components/prompt-detail/molecules/PromptDetailProductDescription.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useState } from "react"
 import { Card, CardContent } from "@repo/ui/card"
 import { ArrowDownCircleIcon, ArrowUpCircleIcon } from "@repo/ui/lucide"

--- a/apps/client/src/components/prompt-detail/molecules/PromptDetailProductDescription.tsx
+++ b/apps/client/src/components/prompt-detail/molecules/PromptDetailProductDescription.tsx
@@ -17,14 +17,12 @@ export default function PromptDetailProductDescription({
 		setIsExpanded(!isExpanded)
 	}
 
-	const isLongDescription = productDescription.split("\n").length > 3
-
 	return (
-		<div className="max-w-[800px]">
+		<div className="max-w-[820px]">
 			<Card className="border-none bg-[#252525] shadow-lg">
 				<CardContent className="p-6">
 					<div className="flex justify-between">
-						<p className="mb-4 text-xl font-bold text-white">Description</p>
+						<p className="text-xl font-bold text-white">Description</p>
 						{isExpanded ? (
 							<ArrowUpCircleIcon
 								className="cursor-pointer text-white"
@@ -39,13 +37,13 @@ export default function PromptDetailProductDescription({
 					</div>
 
 					<p
-						className={`text-lg leading-relaxed text-[#969696] ${isExpanded ? "" : "line-clamp-3"}`}>
+						className={`text-lg leading-relaxed text-[#969696] transition-all duration-500 ease-in-out ${
+							isExpanded
+								? "mt-4 max-h-[1000px] opacity-100"
+								: "max-h-0 overflow-hidden opacity-0"
+						}`}>
 						{productDescription}
 					</p>
-
-					{!isExpanded && isLongDescription ? (
-						<span className="text-[#969696]">...</span>
-					) : null}
 				</CardContent>
 			</Card>
 		</div>

--- a/apps/client/src/components/prompt-detail/molecules/PromptDetailReviewContent.tsx
+++ b/apps/client/src/components/prompt-detail/molecules/PromptDetailReviewContent.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link"
+import { Avatar, AvatarFallback, AvatarImage } from "@repo/ui/avatar"
+import { ReviewDateFormatted } from "@/lib/utils"
+import PromptDetailReviewLine from "../atoms/PromptDetailReviewLine"
+
+interface PromptDetailReviewContentProps {
+	memberNickname: string
+	memberProfileImage: string | undefined
+	updatedAt: string
+	content: string
+}
+
+export default function PromptDetailReviewContent({
+	memberNickname,
+	memberProfileImage,
+	updatedAt,
+	content,
+}: PromptDetailReviewContentProps) {
+	const formDate = ReviewDateFormatted(updatedAt)
+
+	return (
+		<li className="rounded-md bg-[#1b1b1b]">
+			<div className="min-h-[140px]">
+				<Link
+					href={`/profile/${memberNickname}`}
+					className="ml-5 mt-2 flex items-center gap-4 lg:ml-10 lg:mt-4">
+					<Avatar className="h-6 w-6 lg:h-8 lg:w-8">
+						<AvatarImage src={memberProfileImage} alt={memberNickname} />
+						<AvatarFallback>AU</AvatarFallback>
+					</Avatar>
+					<p className="mt-1 text-base font-bold lg:text-xl">
+						{memberNickname}
+					</p>
+					<p className="mx-3 mt-2 text-xs text-[#848898] lg:mx-6 lg:mt-3 lg:text-sm">
+						{formDate}
+					</p>
+				</Link>
+				<PromptDetailReviewLine content={content} />
+			</div>
+		</li>
+	)
+}

--- a/apps/client/src/components/prompt-detail/organisms/PromptDetailReviewCount.tsx
+++ b/apps/client/src/components/prompt-detail/organisms/PromptDetailReviewCount.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+
+interface PromptDetailReviewCountProps {
+	reviewCount: number
+}
+
+export default function PromptDetailReviewCount({
+	reviewCount,
+}: PromptDetailReviewCountProps) {
+	return (
+		<div className="flex items-center justify-between gap-4">
+			<p className="text-4xl font-semibold">Prompt reviews</p>
+			<p className="mx-6 text-base">
+				<span>reviews : {reviewCount}</span>
+			</p>
+		</div>
+	)
+}

--- a/apps/client/src/components/prompt-detail/organisms/PromptDetailThumbnail.tsx
+++ b/apps/client/src/components/prompt-detail/organisms/PromptDetailThumbnail.tsx
@@ -19,6 +19,7 @@ export default function PromptDetailThumbnail({
 				alt={productUUID}
 				fill
 				className="object-cover"
+				priority
 			/>
 		</div>
 	)

--- a/apps/client/src/components/prompt-detail/organisms/PromptReviewContents.tsx
+++ b/apps/client/src/components/prompt-detail/organisms/PromptReviewContents.tsx
@@ -1,0 +1,31 @@
+import type { PromptReviewType } from "@/types/review/reviewType"
+import PromptDetailNoReview from "../molecules/PromptDetailNoReview"
+import PromptDetailReviewContent from "../molecules/PromptDetailReviewContent"
+
+interface PromptReviewContentsProps {
+	productReview: PromptReviewType
+}
+
+export default function PromptReviewContents({
+	productReview,
+}: PromptReviewContentsProps) {
+	return (
+		<div>
+			{productReview.content.length > 0 ? (
+				<ul className="mr-6 grid grid-cols-2 gap-1 lg:grid-cols-1">
+					{productReview.content.map((review) => (
+						<PromptDetailReviewContent
+							key={review.id}
+							memberNickname={review.memberNickname}
+							memberProfileImage={review.memberProfileImage}
+							updatedAt={review.updatedAt}
+							content={review.content}
+						/>
+					))}
+				</ul>
+			) : (
+				<PromptDetailNoReview />
+			)}
+		</div>
+	)
+}

--- a/apps/client/src/components/prompt-detail/templates/PromptDetailTemplate.tsx
+++ b/apps/client/src/components/prompt-detail/templates/PromptDetailTemplate.tsx
@@ -1,7 +1,9 @@
 import type { PromptDetailInfoType } from "@/types/prompt-detail/promptDetailType"
 import type { PromptReviewType } from "@/types/review/reviewType"
 import PromptDetailInfo from "../organisms/PromptDetailInfo"
+import PromptDetailReviewCount from "../organisms/PromptDetailReviewCount"
 import PromptDetailThumbnail from "../organisms/PromptDetailThumbnail"
+import PromptReviewContents from "../organisms/PromptReviewContents"
 
 interface PromptDetailProps {
 	productDetail: PromptDetailInfoType
@@ -28,8 +30,8 @@ export default function PromptDetailTemplate({
 			</div>
 
 			<div className="container mx-auto flex flex-col gap-8 text-white">
-				<div className="text-4xl font-semibold">Prompt reviews</div>
-				<div className="bg-[#1b1b1b]">{productReview.content[1].id}</div>
+				<PromptDetailReviewCount reviewCount={productReview.content.length} />
+				<PromptReviewContents productReview={productReview} />
 			</div>
 		</section>
 	)

--- a/apps/client/src/components/prompt-detail/templates/PromptDetailTemplate.tsx
+++ b/apps/client/src/components/prompt-detail/templates/PromptDetailTemplate.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import type { PromptDetailInfoType } from "@/types/prompt-detail/promptDetailType"
 import type { PromptReviewType } from "@/types/review/reviewType"
 import PromptDetailInfo from "../organisms/PromptDetailInfo"
@@ -7,7 +5,7 @@ import PromptDetailThumbnail from "../organisms/PromptDetailThumbnail"
 
 interface PromptDetailProps {
 	productDetail: PromptDetailInfoType
-	productReview: PromptReviewType[]
+	productReview: PromptReviewType
 }
 
 export default function PromptDetailTemplate({
@@ -15,18 +13,24 @@ export default function PromptDetailTemplate({
 	productReview,
 }: PromptDetailProps) {
 	return (
-		<div className="container mx-auto rounded-lg bg-[#1b1b1b] p-6">
-			<div className="flex gap-20 sm:flex-col lg:flex-row">
-				<PromptDetailThumbnail
-					thumbnailUrl={productDetail.thumbnailUrl}
-					productUUID={productDetail.productUUID}
-				/>
+		<section className="flex flex-col gap-16">
+			<div className="container mx-auto rounded-lg">
+				<div className="flex gap-20 sm:flex-col lg:flex-row">
+					<PromptDetailThumbnail
+						thumbnailUrl={productDetail.thumbnailUrl}
+						productUUID={productDetail.productUUID}
+					/>
 
-				<div className="flex min-h-[800px] flex-grow flex-col gap-12">
-					<PromptDetailInfo productDetail={productDetail} />
+					<div className="flex min-h-[800px] flex-grow flex-col gap-12">
+						<PromptDetailInfo productDetail={productDetail} />
+					</div>
 				</div>
 			</div>
-			<div>{productReview.length ? productReview.length : null}</div>
-		</div>
+
+			<div className="container mx-auto flex flex-col gap-8 text-white">
+				<div className="text-4xl font-semibold">Prompt reviews</div>
+				<div className="bg-[#1b1b1b]">{productReview.content[1].id}</div>
+			</div>
+		</section>
 	)
 }

--- a/apps/client/src/components/prompts/atom/prompts/PromptThumbnail.tsx
+++ b/apps/client/src/components/prompts/atom/prompts/PromptThumbnail.tsx
@@ -15,6 +15,7 @@ function PromptThumbnail({ imageUrl, title }: PromptThumbnailProps) {
 			src={imageUrl || defaultImageUrl}
 			alt={title}
 			className="h-40 w-full rounded-t-lg object-cover"
+			priority
 		/>
 	)
 }

--- a/apps/client/src/dummy/prompt-detail/promptDetailDatas.ts
+++ b/apps/client/src/dummy/prompt-detail/promptDetailDatas.ts
@@ -16,6 +16,7 @@ export const ProductDetailData: PromptDetailInfoType = {
 	memberProfileImage:
 		"https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/TestAvartar.png",
 	memberNickname: "나는 판매자 별칭",
+	isBuy: true,
 	isCart: false,
 	isFavorite: false,
 }

--- a/apps/client/src/dummy/review/productReviewDatas.ts
+++ b/apps/client/src/dummy/review/productReviewDatas.ts
@@ -20,7 +20,8 @@ export const ProductReviewDatas: PromptReviewType = {
 			memberProfileImage:
 				"https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/TestAvartar.png",
 			memberNickname: "ChocoChoc",
-			content: "가격 대비 성능이 좋습니다.",
+			content:
+				"가격 대비 성능이 좋습니다.가격 대비 성능이 좋습니다.가격 대비 성능이 좋습니다.가격 대비 성능이 좋습니다.가격 대비 성능이 좋습니다.가격 대비 성능이 좋습니다.가격 대비 성능이 좋습니다.",
 			createdAt: "2024-11-02T12:30:00.000Z",
 			updatedAt: "2024-11-02T12:30:00.000Z",
 		},
@@ -42,7 +43,8 @@ export const ProductReviewDatas: PromptReviewType = {
 			memberProfileImage:
 				"https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/TestAvartar.png",
 			memberNickname: "ChocoChoc",
-			content: "디자인이 마음에 듭니다. 자주 사용하고 있어요.",
+			content:
+				"디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 자주 사용하고 있어요.디자인이 마음에 듭니다. 자주 사용하고 있어요.",
 			createdAt: "2024-11-04T09:15:00.000Z",
 			updatedAt: "2024-11-04T09:15:00.000Z",
 		},

--- a/apps/client/src/dummy/review/productReviewDatas.ts
+++ b/apps/client/src/dummy/review/productReviewDatas.ts
@@ -1,45 +1,55 @@
 import type { PromptReviewType } from "@/types/review/reviewType"
 
-export const ProductReviewDatas: PromptReviewType[] = [
-	{
-		content: [
-			{
-				id: 1,
-				productUuid: "prod-uuid-1",
-				memberUuid: "member-uuid-1",
-				content: "이 제품은 정말 훌륭합니다! 강력 추천합니다.",
-				createdAt: "2024-11-01T10:00:00.000Z",
-				updatedAt: "2024-11-01T10:00:00.000Z",
-			},
-			{
-				id: 2,
-				productUuid: "prod-uuid-2",
-				memberUuid: "member-uuid-2",
-				content: "가격 대비 성능이 좋습니다.",
-				createdAt: "2024-11-02T12:30:00.000Z",
-				updatedAt: "2024-11-02T12:30:00.000Z",
-			},
-			{
-				id: 3,
-				productUuid: "prod-uuid-3",
-				memberUuid: "member-uuid-3",
-				content: "배송이 빨랐고, 품질도 만족스럽습니다.",
-				createdAt: "2024-11-03T14:45:00.000Z",
-				updatedAt: "2024-11-03T14:45:00.000Z",
-			},
-			{
-				id: 4,
-				productUuid: "prod-uuid-4",
-				memberUuid: "member-uuid-4",
-				content: "디자인이 마음에 듭니다. 자주 사용하고 있어요.",
-				createdAt: "2024-11-04T09:15:00.000Z",
-				updatedAt: "2024-11-04T09:15:00.000Z",
-			},
-		],
-		lastCreatedAt: "2024-11-05T02:21:13.550Z",
-		lastId: 4,
-		hasNext: false,
-		pageSize: 5,
-		page: 1,
-	},
-]
+export const ProductReviewDatas: PromptReviewType = {
+	content: [
+		{
+			id: 1,
+			productUuid: "prod-uuid-1",
+			memberUuid: "member-uuid-1",
+			memberProfileImage:
+				"https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/TestAvartar.png",
+			memberNickname: "ChocoChoc",
+			content: "이 제품은 정말 훌륭합니다! 강력 추천합니다.",
+			createdAt: "2024-11-01T10:00:00.000Z",
+			updatedAt: "2024-11-01T10:00:00.000Z",
+		},
+		{
+			id: 2,
+			productUuid: "prod-uuid-2",
+			memberUuid: "member-uuid-2",
+			memberProfileImage:
+				"https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/TestAvartar.png",
+			memberNickname: "ChocoChoc",
+			content: "가격 대비 성능이 좋습니다.",
+			createdAt: "2024-11-02T12:30:00.000Z",
+			updatedAt: "2024-11-02T12:30:00.000Z",
+		},
+		{
+			id: 3,
+			productUuid: "prod-uuid-3",
+			memberUuid: "member-uuid-3",
+			memberProfileImage:
+				"https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/TestAvartar.png",
+			memberNickname: "ChocoChoc",
+			content: "배송이 빨랐고, 품질도 만족스럽습니다.",
+			createdAt: "2024-11-03T14:45:00.000Z",
+			updatedAt: "2024-11-03T14:45:00.000Z",
+		},
+		{
+			id: 4,
+			productUuid: "prod-uuid-4",
+			memberUuid: "member-uuid-4",
+			memberProfileImage:
+				"https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/TestAvartar.png",
+			memberNickname: "ChocoChoc",
+			content: "디자인이 마음에 듭니다. 자주 사용하고 있어요.",
+			createdAt: "2024-11-04T09:15:00.000Z",
+			updatedAt: "2024-11-04T09:15:00.000Z",
+		},
+	],
+	lastCreatedAt: "2024-11-05T02:21:13.550Z",
+	lastId: 4,
+	hasNext: false,
+	pageSize: 5,
+	page: 1,
+}

--- a/apps/client/src/lib/utils.ts
+++ b/apps/client/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs))
 }
+
+//Date Formmat like -> at 2.45 PM
+export const ReviewDateFormatted = (dateString: string) => {
+	const date = new Date(dateString)
+	const hours = date.getUTCHours()
+	const minutes = date.getUTCMinutes()
+	const ampm = hours >= 12 ? "PM" : "AM"
+	const formattedHours = hours % 12 || 12
+	const formattedMinutes = minutes < 10 ? `0${minutes}` : minutes
+	return `at ${formattedHours}.${formattedMinutes} ${ampm}`
+}

--- a/apps/client/src/types/prompt-detail/promptDetailType.ts
+++ b/apps/client/src/types/prompt-detail/promptDetailType.ts
@@ -11,6 +11,7 @@ export interface PromptDetailInfoType {
 	bio: string | undefined
 	memberProfileImage: string | undefined
 	memberNickname: string | undefined
+	isBuy: boolean
 	isCart: boolean
 	isFavorite: boolean
 }

--- a/apps/client/src/types/review/reviewType.ts
+++ b/apps/client/src/types/review/reviewType.ts
@@ -10,8 +10,10 @@ export interface PromptReviewType {
 export interface ReviewContentType {
 	id: number // 리뷰 ID
 	productUuid: string // 제품 UUID
-	memberUuid: string // 회원 UUID
 	content: string // 리뷰 내용
 	createdAt: string // 생성 일자 (ISO 8601 형식)
 	updatedAt: string // 업데이트 일자 (ISO 8601 형식)
+	memberUuid: string // 회원 UUID
+	memberProfileImage: string // 회원 프로필
+	memberNickname: string //회원 별칭
 }


### PR DESCRIPTION
[API]
1. 최초 리뷰는 4개까지만 호출
2. 추후 추가될 '더보기' 등을 통해 모달에서 리뷰를 관리할 예정
3. 기존 Creator의 모든 리뷰를 관리하는 것에서 해당 Prompt만의 리뷰를 보는 것으로 변경

---------------------------------------------------------------------------------------------------

[반응형 적용 내역]
1. grid-col-2 ~ grid-col-4
2. line-clamp-2 ~ line-clamp-5
3. 마진, 패딩, 폰트 등등

---------------------------------------------------------------------------------------------------

[최종 데이터 타입 - 추후 변경될 수도 있음]
export interface PromptReviewType {
	content: ReviewContentType[]
	lastCreatedAt: string // ISO 8601 형식의 날짜 문자열
	lastId: number // 마지막 ID
	hasNext: boolean // 다음 페이지 존재 여부
	pageSize: number // 페이지 크기
	page: number // 현재 페이지 번호
}

export interface ReviewContentType {
	id: number // 리뷰 ID
	productUuid: string // 제품 UUID
	content: string // 리뷰 내용
	createdAt: string // 생성 일자 (ISO 8601 형식)
	updatedAt: string // 업데이트 일자 (ISO 8601 형식)
	memberUuid: string // 회원 UUID
	memberProfileImage: string | undefined // 회원 프로필
	memberNickname: string //회원 별칭
}