### PR TITLE
Modify/jyxb 322 fe modify header component

### DIFF
--- a/apps/client/src/app/account/[[...slug]]/layout.tsx
+++ b/apps/client/src/app/account/[[...slug]]/layout.tsx
@@ -1,10 +1,7 @@
-import React from "react"
-import { SideMenuToggleStoreProvider } from "@/provider/account/sideMenuStoreProvider.tsx"
-
 export default function Layout({
 	children,
 }: {
 	children: Readonly<React.ReactNode>
 }) {
-	return <SideMenuToggleStoreProvider>{children}</SideMenuToggleStoreProvider>
+	return <main>{children}</main>
 }

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -3,8 +3,8 @@ import "./globals.css"
 import "@repo/ui/styles.css"
 import type { Metadata } from "next"
 import { roboto, sora } from "@/app/fonts.ts"
-import MainHeader from "@/components/main/molecule/MainHeader.tsx"
-// import MainHeader from "@/components/common/molecule/MainHeader.tsx"
+// import MainHeader from "@/components/main/molecule/MainHeader.tsx"
+import MainHeader from "@/components/common/molecule/MainHeader.tsx"
 import { AuthSessionProvider } from "@/provider/authSessionProvider.tsx"
 
 export const metadata: Metadata = {

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { roboto, sora } from "@/app/fonts.ts"
 // import MainHeader from "@/components/main/molecule/MainHeader.tsx"
 import MainHeader from "@/components/common/molecule/MainHeader.tsx"
 import { AuthSessionProvider } from "@/provider/authSessionProvider.tsx"
+import { SideMenuToggleStoreProvider } from "@/provider/account/sideMenuStoreProvider.tsx"
 
 export const metadata: Metadata = {
 	title: "Prompt Oven",
@@ -41,8 +42,10 @@ export default function RootLayout({
 			<body
 				className={`${sora.variable} ${roboto.variable} ${sora.className} bg-po-black-200`}>
 				<AuthSessionProvider>
-					<MainHeader />
-					{children}
+					<SideMenuToggleStoreProvider>
+						<MainHeader />
+						{children}
+					</SideMenuToggleStoreProvider>
 				</AuthSessionProvider>
 			</body>
 		</html>

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -3,8 +3,8 @@ import "./globals.css"
 import "@repo/ui/styles.css"
 import type { Metadata } from "next"
 import { roboto, sora } from "@/app/fonts.ts"
-// import MainHeader from "@/components/main/molecule/MainHeader.tsx"
-import MainHeader from "@/components/common/molecule/MainHeader.tsx"
+import MainHeader from "@/components/main/molecule/MainHeader.tsx"
+// import MainHeader from "@/components/common/molecule/MainHeader.tsx"
 import { AuthSessionProvider } from "@/provider/authSessionProvider.tsx"
 
 export const metadata: Metadata = {

--- a/apps/client/src/app/layout.tsx
+++ b/apps/client/src/app/layout.tsx
@@ -3,7 +3,8 @@ import "./globals.css"
 import "@repo/ui/styles.css"
 import type { Metadata } from "next"
 import { roboto, sora } from "@/app/fonts.ts"
-import MainHeader from "@/components/main/molecule/MainHeader.tsx"
+// import MainHeader from "@/components/main/molecule/MainHeader.tsx"
+import MainHeader from "@/components/common/molecule/MainHeader.tsx"
 import { AuthSessionProvider } from "@/provider/authSessionProvider.tsx"
 
 export const metadata: Metadata = {
@@ -38,7 +39,7 @@ export default function RootLayout({
 				<meta name="mobile-web-app-capable" content="yes" />
 			</head>
 			<body
-				className={`${sora.variable} ${roboto.variable} ${sora.className} bg-[#111111]`}>
+				className={`${sora.variable} ${roboto.variable} ${sora.className} bg-po-black-200`}>
 				<AuthSessionProvider>
 					<MainHeader />
 					{children}

--- a/apps/client/src/components/account/atom/SideMenuItem.tsx
+++ b/apps/client/src/components/account/atom/SideMenuItem.tsx
@@ -2,13 +2,13 @@ import type { ComponentProps } from "react"
 import React from "react"
 import Link from "next/link"
 import { cn } from "@/lib/utils.ts"
-import type { MenuItemIconType } from "@/types/account/accountSideMenuType.ts"
+import type { MenuIconType } from "@/lib/navigation.ts"
 
 interface SideMenuItemProps extends ComponentProps<typeof Link> {
 	view: string
 	label: string
 	activeRoute: string
-	Icon: MenuItemIconType
+	Icon: MenuIconType
 }
 
 function SideMenuItem({
@@ -22,8 +22,8 @@ function SideMenuItem({
 		<Link
 			{...props}
 			className={cn(
-				"flex h-[60px] items-center justify-between rounded-lg px-5 py-4 transition-colors hover:bg-white/10",
-				view.includes(activeRoute) && "text-[#E2ADFF]",
+				"flex h-[60px] items-center justify-between rounded-lg px-5 py-4 transition-colors hover:!bg-white/10",
+				view.includes(activeRoute) ? "text-[#E2ADFF]" : "text-white",
 				props.className,
 			)}>
 			<div className="flex items-center gap-3">

--- a/apps/client/src/components/account/molecule/SideMenuToggleItem.tsx
+++ b/apps/client/src/components/account/molecule/SideMenuToggleItem.tsx
@@ -4,20 +4,18 @@ import type { HTMLAttributes } from "react"
 import React from "react"
 import { ChevronUp } from "@repo/ui/lucide"
 import { cn } from "@/lib/utils.ts"
-import type {
-	MenuItemIconType,
-	SubMenuItemType,
-} from "@/types/account/accountSideMenuType.ts"
 import SideMenuToggleSubItem from "@/components/account/atom/SideMenuToggleSubItem.tsx"
 import { routes } from "@/config/account/route.ts"
 import { useSideMenuToggleStore } from "@/provider/account/sideMenuStoreProvider.tsx"
+import type { MenuIconType, SubMenuItemType } from "@/lib/navigation.ts"
 
 interface SideMenuToggleItemProps extends HTMLAttributes<HTMLDivElement> {
 	label: string
 	view: string
 	activeRoute: string
 	subMenu: SubMenuItemType[]
-	Icon: MenuItemIconType
+	Icon: MenuIconType
+	subMenuProps?: HTMLAttributes<HTMLDivElement>
 }
 
 function SideMenuToggleItem({
@@ -26,6 +24,7 @@ function SideMenuToggleItem({
 	label,
 	view,
 	Icon,
+	                            subMenuProps,
 	...props
 }: SideMenuToggleItemProps) {
 	const { sideMenuItems, toggleSideMenuItem } = useSideMenuToggleStore(
@@ -45,9 +44,9 @@ function SideMenuToggleItem({
 				}}
 				{...props}
 				className={cn(
-					"flex h-[60px] items-center justify-between rounded-lg px-5 py-4 transition-colors hover:bg-white/10",
+					"flex h-[60px] items-center justify-between rounded-lg px-5 py-4 transition-colors hover:!bg-white/10",
 					// note: 상위 메뉴의 색상이 반영되려면 activeRoute 텍스트가 view를 포함하고 있어야 함
-					activeRoute.includes(view) && "text-[#E2ADFF]",
+					activeRoute.includes(view) ? "text-[#E2ADFF]" : "text-white",
 					props.className,
 				)}>
 				<div className="flex items-center gap-3">
@@ -56,15 +55,17 @@ function SideMenuToggleItem({
 				</div>
 				<ChevronUp
 					className={cn(
-						"h-5 w-5 text-white transition-transform",
+						"h-5 w-5 !text-white transition-transform",
 						isOpen ? "rotate-0" : "rotate-180",
 					)}
 				/>
 			</div>
 			<div
+				{...subMenuProps}
 				className={cn(
 					"transition-max-height flex flex-col gap-2 pl-4 duration-500 ease-in",
 					isOpen ? "max-h-screen" : "max-h-0 overflow-hidden",
+					subMenuProps?.className
 				)}>
 				{subMenu.map((item, index) => (
 					<SideMenuToggleSubItem
@@ -72,9 +73,9 @@ function SideMenuToggleItem({
 						key={index}
 						href={{
 							pathname: routes.account,
-							query: { view: item.view },
+							query: { view: item.query },
 						}}
-						view={item.view}
+						view={item.query}
 						label={item.label}
 						activeRoute={activeRoute}
 					/>

--- a/apps/client/src/components/account/organism/SideMenu.tsx
+++ b/apps/client/src/components/account/organism/SideMenu.tsx
@@ -1,10 +1,9 @@
-import React, { Fragment } from "react"
-import Link from "next/link"
+import React from "react"
 import { cn } from "@/lib/utils.ts"
-import type { MenuNavItemType } from "@/types/account/accountSideMenuType.ts"
 import SideMenuItem from "@/components/account/atom/SideMenuItem.tsx"
 import SideMenuToggleItem from "@/components/account/molecule/SideMenuToggleItem.tsx"
 import { routes } from "@/config/account/route.ts"
+import type { MenuNavItemType } from "@/lib/navigation.ts"
 
 interface AccountSideMenuProps {
 	menuItems: MenuNavItemType[]
@@ -13,67 +12,42 @@ interface AccountSideMenuProps {
 
 function SideMenu({ menuItems, activeRoute }: AccountSideMenuProps) {
 	return (
-		<>
-			{/* Navigation bar for smaller screens */}
-			<nav className="z-5 absolute left-0 right-0 top-0 flex h-12 items-center justify-start overflow-hidden border-b-[1px] border-[#424242] bg-[#111111] px-4 text-white lg:!hidden">
-				{menuItems.map((item, index) => (
-					<Link
-						// eslint-disable-next-line react/no-array-index-key -- This is a static array
-						key={index}
-						href={{
-							pathname: routes.account_product,
-							query: { view: item.view },
-						}}
-						className={cn(
-							"flex h-full items-center whitespace-nowrap px-3",
-							item.view.includes(activeRoute)
-								? "border-b-2 border-[#E2ADFF] text-[#E2ADFF]"
-								: "text-white",
-						)}>
-						<item.icon className="mr-2 h-5 w-5" />
-						<span className="text-sm font-medium">{item.label}</span>
-					</Link>
-				))}
-			</nav>
-
-			{/* Sidebar */}
-			<div
-				className={cn(
-					"z-5 absolute inset-y-0 left-0 w-64 -translate-x-full transform border-r-[1px] border-[#424242] bg-[#111111] text-white transition-transform duration-200 ease-in-out lg:!relative lg:!translate-x-0",
-					// isMobileMenuOpen ? "translate-x-0" : "-translate-x-full",
-				)}>
-				<div className="flex h-full flex-1 flex-col overflow-y-auto">
-					<div className="flex flex-col gap-2 p-4">
-						{menuItems.map((item, index) =>
-							item.subMenu ? (
-								<SideMenuToggleItem
-									// eslint-disable-next-line react/no-array-index-key -- This is a static array
-									key={index}
-									view={item.view}
-									label={item.label}
-									activeRoute={activeRoute}
-									Icon={item.icon}
-									subMenu={item.subMenu}
-								/>
-							) : (
-								<SideMenuItem
-									// eslint-disable-next-line react/no-array-index-key -- This is a static array
-									key={index}
-									href={{
-										pathname: routes.account,
-										query: { view: item.view },
-									}}
-									view={item.view}
-									label={item.label}
-									activeRoute={activeRoute}
-									Icon={item.icon}
-								/>
-							),
-						)}
-					</div>
+		<div
+			className={cn(
+				"z-5 absolute inset-y-0 left-0 w-64 -translate-x-full transform border-r-[1px] border-[#424242] bg-[#111111] text-white transition-transform duration-200 ease-in-out lg:!relative lg:!translate-x-0",
+				// isMobileMenuOpen ? "translate-x-0" : "-translate-x-full",
+			)}>
+			<div className="flex h-full flex-1 flex-col overflow-y-auto">
+				<div className="flex flex-col gap-2 p-4">
+					{menuItems.map((item, index) =>
+						item.subMenu ? (
+							<SideMenuToggleItem
+								// eslint-disable-next-line react/no-array-index-key -- This is a static array
+								key={index}
+								view={item.query}
+								label={item.label}
+								activeRoute={activeRoute}
+								Icon={item.icon}
+								subMenu={item.subMenu}
+							/>
+						) : (
+							<SideMenuItem
+								// eslint-disable-next-line react/no-array-index-key -- This is a static array
+								key={index}
+								href={{
+									pathname: routes.account,
+									query: { view: item.query },
+								}}
+								view={item.query}
+								label={item.label}
+								activeRoute={activeRoute}
+								Icon={item.icon}
+							/>
+						),
+					)}
 				</div>
 			</div>
-		</>
+		</div>
 	)
 }
 

--- a/apps/client/src/components/account/template/ContentWrapper.tsx
+++ b/apps/client/src/components/account/template/ContentWrapper.tsx
@@ -1,41 +1,9 @@
 "use client"
 
 import * as React from "react"
-import {
-	FileText,
-	Heart,
-	LayoutDashboard,
-	Package,
-	Settings,
-	ShoppingBag,
-	TagsIcon,
-	User,
-	Wallet,
-} from "@repo/ui/lucide"
-import type { MenuNavItemType } from "@/types/account/accountSideMenuType.ts"
 import SideMenu from "@/components/account/organism/SideMenu.tsx"
 import type { QueryParams } from "@/types/account/searchParams.ts"
-
-const menuItems: MenuNavItemType[] = [
-	{ icon: LayoutDashboard, label: "Overview", view: "overview" },
-	{
-		icon: Package,
-		label: "Product",
-		view: "product",
-		subMenu: [
-			{ label: "Create Product", view: "create-product" },
-			{ label: "Product List", view: "product-list" },
-			{ label: "Category", view: "product-category" },
-		],
-	},
-	{ icon: User, label: "Profile", view: "profile" },
-	{ icon: FileText, label: "Prompts", view: "prompts" },
-	{ icon: TagsIcon, label: "Sales", view: "sales" },
-	{ icon: Wallet, label: "Payouts", view: "payouts" },
-	{ icon: ShoppingBag, label: "Purchases", view: "purchases" },
-	{ icon: Heart, label: "Favorites", view: "favorites" },
-	{ icon: Settings, label: "Settings", view: "settings" },
-]
+import { sellerNavs } from "@/lib/navigation.ts"
 
 interface AccountContentWrapperProps {
 	children?: React.ReactNode
@@ -50,7 +18,7 @@ export default function ContentWrapper({
 
 	return (
 		<div className="relative flex h-[calc(100vh-80px)]">
-			<SideMenu menuItems={menuItems} activeRoute={view} />
+			<SideMenu menuItems={sellerNavs} activeRoute={view} />
 
 			{/* Main content */}
 			<div className="mt-12 flex-1 p-4 lg:mt-0 lg:p-8">{children}</div>

--- a/apps/client/src/components/common/atom/Avatar.tsx
+++ b/apps/client/src/components/common/atom/Avatar.tsx
@@ -22,13 +22,13 @@ export default function Avatar({
 }: AvatarProps) {
 	return (
 		<ShadcnAvatar
+			{...props}
 			className={cn(
-				"inline-flex items-center justify-center rounded-full",
+				"box-border inline-flex items-center justify-center rounded-full",
 				"border border-[#424242] bg-transparent",
 				className,
 			)}
-			style={{ width: `${size}px`, height: `${size}px` }}
-			{...props}>
+			style={{ width: `${size / 16}rem`, height: `${size / 16}rem` }}>
 			{src ? (
 				<AvatarImage
 					src={src}

--- a/apps/client/src/components/common/atom/BadgeContainer.tsx
+++ b/apps/client/src/components/common/atom/BadgeContainer.tsx
@@ -1,0 +1,30 @@
+import type { HTMLAttributes, ReactNode } from "react"
+import * as React from "react"
+import { cn } from "@/lib/utils.ts"
+
+interface BadgeContainerProps extends HTMLAttributes<HTMLDivElement> {
+	children?: ReactNode
+	count?: number
+}
+
+function BadgeContainer({ children, count, ...props }: BadgeContainerProps) {
+	const displayCount = count && count > 9 ? "9+" : count
+
+	return (
+		<div
+			{...props}
+			className={cn(
+				"relative flex h-12 w-12 items-center justify-center",
+				props.className,
+			)}>
+			{children}
+			{count && count > 0 ? (
+				<span className="absolute right-[0px] top-[0px] flex h-5 min-w-5 items-center justify-center rounded-full border-2 border-[#A100F8] bg-[#A913F9] px-1 text-xs font-medium text-white">
+					{displayCount}
+				</span>
+			) : null}
+		</div>
+	)
+}
+
+export default BadgeContainer

--- a/apps/client/src/components/common/atom/Header.tsx
+++ b/apps/client/src/components/common/atom/Header.tsx
@@ -10,7 +10,7 @@ export interface HeaderProps
 // note: 필요에 따라 기본 반응형 코드를 작성할 필요가 있음
 const defaultHeaderClassName = "flex w-full justify-center items-center"
 const defaultInnerContainerClassName =
-	"mx-auto flex h-20 w-full max-w-[1716px] items-center justify-between px-4"
+	"mx-auto flex h-20 w-full max-w-[1720px] items-center justify-between px-4"
 
 export default function Header({
 	children,

--- a/apps/client/src/components/common/atom/Header.tsx
+++ b/apps/client/src/components/common/atom/Header.tsx
@@ -1,0 +1,32 @@
+import type { DetailedHTMLProps, HTMLAttributes, ReactNode } from "react"
+import { cn } from "@/lib/utils.ts"
+
+export interface HeaderProps
+	extends DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> {
+	children?: ReactNode
+	innerContainerProps?: HTMLAttributes<HTMLDivElement>
+}
+
+// note: 필요에 따라 기본 반응형 코드를 작성할 필요가 있음
+const defaultHeaderClassName = "flex w-full justify-center items-center"
+const defaultInnerContainerClassName =
+	"mx-auto flex h-20 w-full max-w-[1716px] items-center justify-between px-4"
+
+export default function Header({
+	children,
+	innerContainerProps,
+	...props
+}: HeaderProps) {
+	return (
+		<header {...props} className={cn(defaultHeaderClassName, props.className)}>
+			<div
+				{...innerContainerProps}
+				className={cn(
+					defaultInnerContainerClassName,
+					innerContainerProps?.className,
+				)}>
+				{children}
+			</div>
+		</header>
+	)
+}

--- a/apps/client/src/components/common/atom/Header.tsx
+++ b/apps/client/src/components/common/atom/Header.tsx
@@ -8,9 +8,10 @@ export interface HeaderProps
 }
 
 // note: 필요에 따라 기본 반응형 코드를 작성할 필요가 있음
-const defaultHeaderClassName = "flex w-full justify-center items-center"
+const defaultHeaderClassName =
+	"flex w-full justify-center items-center border-b-[1px] border-[#424242]"
 const defaultInnerContainerClassName =
-	"mx-auto flex h-20 w-full max-w-[1720px] items-center justify-between px-4"
+	"mx-auto flex h-20 w-full max-w-[1720px] items-center justify-between px-5"
 
 export default function Header({
 	children,

--- a/apps/client/src/components/common/atom/MainHeaderLinkList.tsx
+++ b/apps/client/src/components/common/atom/MainHeaderLinkList.tsx
@@ -1,0 +1,25 @@
+import type { HTMLAttributes } from "react"
+import { mainNavs } from "@/lib/navigation.ts"
+import NavLink from "@/components/common/atom/NavLink.tsx"
+import { cn } from "@/lib/utils.ts"
+
+type MainHeaderLinkListProps = HTMLAttributes<HTMLUListElement>
+
+function MainHeaderLinkList({ ...props }: MainHeaderLinkListProps) {
+	return (
+		<ul
+			{...props}
+			className={cn("mx-4 hidden items-center gap-6 xl:flex", props.className)}>
+			{mainNavs.map((nav, index) => (
+				// eslint-disable-next-line react/no-array-index-key -- index is unique
+				<li key={index}>
+					<NavLink href={nav.href} color="#969696" activeColor="#A913F9">
+						{nav.label}
+					</NavLink>
+				</li>
+			))}
+		</ul>
+	)
+}
+
+export default MainHeaderLinkList

--- a/apps/client/src/components/common/atom/NavLink.tsx
+++ b/apps/client/src/components/common/atom/NavLink.tsx
@@ -5,20 +5,20 @@ import { useCallback, useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 
-interface NavAnchorProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+interface NavLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 	href: string
 	color?: string
 	activeColor?: string
 	children?: ReactNode
 }
 
-export default function NavAnchor({
+export default function NavLink({
 	href,
 	children,
 	color = "#D9D9D9",
 	activeColor,
 	...props
-}: NavAnchorProps) {
+}: NavLinkProps) {
 	const pathname = usePathname()
 	const isActive = pathname === href
 	const [isHovered, setIsHovered] = useState(false)

--- a/apps/client/src/components/common/atom/icon/HamburgerIcon.tsx
+++ b/apps/client/src/components/common/atom/icon/HamburgerIcon.tsx
@@ -1,0 +1,27 @@
+import type { SVGProps } from "react"
+
+interface HamburgerIconProps extends SVGProps<SVGSVGElement> {
+	pathProps?: SVGProps<SVGPathElement>
+}
+
+function HamburgerIcon({ pathProps, ...props }: HamburgerIconProps) {
+	return (
+		<svg
+			width="48"
+			height="48"
+			viewBox="0 0 48 48"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+			{...props}>
+			<path
+				fillRule="evenodd"
+				clipRule="evenodd"
+				d="M14.1781 14.9004C13.2945 14.9004 12.5781 15.6167 12.5781 16.5004C12.5781 17.384 13.2945 18.1004 14.1781 18.1004H33.8237C34.7074 18.1004 35.4237 17.384 35.4237 16.5004C35.4237 15.6167 34.7074 14.9004 33.8237 14.9004H14.1781ZM12.5781 24.0004C12.5781 23.1167 13.2945 22.4004 14.1781 22.4004H33.8237C34.7074 22.4004 35.4237 23.1167 35.4237 24.0004C35.4237 24.884 34.7074 25.6004 33.8237 25.6004H14.1781C13.2945 25.6004 12.5781 24.884 12.5781 24.0004ZM12.5781 31.5004C12.5781 30.6167 13.2945 29.9004 14.1781 29.9004H33.8237C34.7074 29.9004 35.4237 30.6167 35.4237 31.5004C35.4237 32.384 34.7074 33.1004 33.8237 33.1004H14.1781C13.2945 33.1004 12.5781 32.384 12.5781 31.5004Z"
+				fill="white"
+				{...pathProps}
+			/>
+		</svg>
+	)
+}
+
+export default HamburgerIcon

--- a/apps/client/src/components/common/molecule/AvatarMenu.tsx
+++ b/apps/client/src/components/common/molecule/AvatarMenu.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import * as React from "react"
+import { Button } from "@repo/ui/button"
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@repo/ui/dropdown-menu"
+import Link from "next/link"
+import Avatar from "@/components/common/atom/Avatar"
+import type { MenuNavItemType } from "@/lib/navigation.ts"
+import { sellerNavs } from "@/lib/navigation.ts"
+
+export function AvatarMenu() {
+	// todo : 유저의 권한에 따라 보여줘야할 내비게이션 아이템이 다름
+	const menuItems: MenuNavItemType[] = sellerNavs
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="ghost"
+					className="relative !h-12 !w-12 rounded-full border-none hover:!bg-transparent focus-visible:!ring-0">
+					<Avatar size={48} />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				className="w-40 rounded-[6px] border-none bg-[#252525] p-4"
+				align="end">
+				{menuItems.map((item, index) => (
+					<Link
+						// eslint-disable-next-line react/no-array-index-key  -- This is a static array
+						key={index}
+						href={{ pathname: item.href, query: { view: item.query } }}>
+						<DropdownMenuItem className="h-[56px] cursor-pointer gap-3 p-0 *:text-white *:hover:text-po-purple-50 focus:bg-[#252525]">
+							<item.icon className="!h-4 !w-4" />
+							<span className="text-base font-normal">{item.label}</span>
+						</DropdownMenuItem>
+					</Link>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	)
+}

--- a/apps/client/src/components/common/molecule/AvatarMenu.tsx
+++ b/apps/client/src/components/common/molecule/AvatarMenu.tsx
@@ -22,7 +22,7 @@ export function AvatarMenu() {
 			<DropdownMenuTrigger asChild>
 				<Button
 					variant="ghost"
-					className="relative !h-12 !w-12 rounded-full border-none hover:!bg-transparent focus-visible:!ring-0">
+					className="relative !hidden !h-12 !w-12 rounded-full border-none hover:!bg-transparent focus-visible:!ring-0 lg:!flex">
 					<Avatar size={48} />
 				</Button>
 			</DropdownMenuTrigger>

--- a/apps/client/src/components/common/molecule/MainHeader.tsx
+++ b/apps/client/src/components/common/molecule/MainHeader.tsx
@@ -4,6 +4,7 @@ import CommonHeader from "@/components/common/atom/Header"
 import MainLogo from "@/components/common/atom/icon/MainLogo.tsx"
 import { mainNavs } from "@/lib/navigation.ts"
 import NavLink from "@/components/common/atom/NavLink.tsx"
+import { AvatarMenu } from "@/components/common/molecule/AvatarMenu.tsx"
 
 export default function MainHeader() {
 	return (
@@ -13,7 +14,9 @@ export default function MainHeader() {
 				<MainLogo />
 			</Link>
 
-			<div className="box-border hidden h-full max-w-2xl flex-1 items-center border-x border-[#424242] px-10 md:flex"></div>
+			<div className="box-border hidden h-full max-w-2xl flex-1 items-center border-x border-[#424242] px-10 md:flex">
+				<div className="h-8 w-full bg-po-gray-100" />
+			</div>
 
 			{/* Navigation */}
 			<ul className="mx-4 hidden items-center gap-6 xl:flex">
@@ -21,11 +24,19 @@ export default function MainHeader() {
 					// eslint-disable-next-line react/no-array-index-key -- index is unique
 					<li key={index}>
 						<NavLink href={nav.href} color="#969696" activeColor="#A913F9">
-							{nav.title}
+							{nav.label}
 						</NavLink>
 					</li>
 				))}
 			</ul>
+
+			{/* Right side buttons */}
+			<div className="hidden items-center gap-8 lg:flex">
+				<AvatarMenu />
+			</div>
+
+			{/* Mobile menu button */}
+			<div className="pl-4 lg:hidden" />
 		</CommonHeader>
-)
+	)
 }

--- a/apps/client/src/components/common/molecule/MainHeader.tsx
+++ b/apps/client/src/components/common/molecule/MainHeader.tsx
@@ -1,10 +1,12 @@
-import React from "react"
+import React, { Suspense } from "react"
 import Link from "next/link"
+import { Bell, MessageSquareText, ShoppingCart } from "@repo/ui/lucide"
 import CommonHeader from "@/components/common/atom/Header"
 import MainLogo from "@/components/common/atom/icon/MainLogo.tsx"
-import { mainNavs } from "@/lib/navigation.ts"
-import NavLink from "@/components/common/atom/NavLink.tsx"
 import { AvatarMenu } from "@/components/common/molecule/AvatarMenu.tsx"
+import BadgeContainer from "@/components/common/atom/BadgeContainer.tsx"
+import { SideBarMenu } from "@/components/common/organism/SideBarMenu.tsx"
+import MainHeaderLinkList from "@/components/common/atom/MainHeaderLinkList.tsx"
 
 export default function MainHeader() {
 	return (
@@ -14,29 +16,38 @@ export default function MainHeader() {
 				<MainLogo />
 			</Link>
 
+			{/* todo: 검색 다이얼로그 컴포넌트 추가 필요 - 모바일 또는 태블릿인 경우 검색 아이콘으로 바뀌는 반응형 작업도 필요함 */}
 			<div className="box-border hidden h-full max-w-2xl flex-1 items-center border-x border-[#424242] px-10 md:flex">
 				<div className="h-8 w-full bg-po-gray-100" />
 			</div>
 
 			{/* Navigation */}
-			<ul className="mx-4 hidden items-center gap-6 xl:flex">
-				{mainNavs.map((nav, index) => (
-					// eslint-disable-next-line react/no-array-index-key -- index is unique
-					<li key={index}>
-						<NavLink href={nav.href} color="#969696" activeColor="#A913F9">
-							{nav.label}
-						</NavLink>
-					</li>
-				))}
-			</ul>
+			<MainHeaderLinkList />
 
 			{/* Right side buttons */}
-			<div className="hidden items-center gap-8 lg:flex">
+			<div className="ml-5 flex items-center gap-5">
+				{/* todo: 현재는 BadgeContainer로만 표현했지만 알림은 알림과 관련된 모달을 띄우고 메시지와 카트는 해당 페이지로 이동해야한다. 그 이후에 컴포넌트로 정의하기*/}
+				<BadgeContainer count={2}>
+					<Bell className="!h-7 !w-7 text-po-gray-150" strokeWidth={2} />
+				</BadgeContainer>
+				<BadgeContainer count={10}>
+					<MessageSquareText
+						className="!h-7 !w-7 text-po-gray-150"
+						strokeWidth={2}
+					/>
+				</BadgeContainer>
+				<BadgeContainer count={10}>
+					<ShoppingCart
+						className="!h-7 !w-7 text-po-gray-150"
+						strokeWidth={2}
+					/>
+				</BadgeContainer>
 				<AvatarMenu />
+				{/* Mobile menu button */}
+				<Suspense fallback={null}>
+					<SideBarMenu />
+				</Suspense>
 			</div>
-
-			{/* Mobile menu button */}
-			<div className="pl-4 lg:hidden" />
 		</CommonHeader>
 	)
 }

--- a/apps/client/src/components/common/molecule/MainHeader.tsx
+++ b/apps/client/src/components/common/molecule/MainHeader.tsx
@@ -1,0 +1,10 @@
+import React from "react"
+import  CommonHeader from "@/components/common/atom/Header"
+
+export default function MainHeader() {
+	return (
+		<CommonHeader className="bg-po-black-200 h-20">
+
+		</CommonHeader>
+	)
+}

--- a/apps/client/src/components/common/molecule/MainHeader.tsx
+++ b/apps/client/src/components/common/molecule/MainHeader.tsx
@@ -1,10 +1,31 @@
 import React from "react"
-import  CommonHeader from "@/components/common/atom/Header"
+import Link from "next/link"
+import CommonHeader from "@/components/common/atom/Header"
+import MainLogo from "@/components/common/atom/icon/MainLogo.tsx"
+import { mainNavs } from "@/lib/navigation.ts"
+import NavLink from "@/components/common/atom/NavLink.tsx"
 
 export default function MainHeader() {
 	return (
-		<CommonHeader className="bg-po-black-200 h-20">
+		<CommonHeader className="h-20 bg-po-black-200">
+			{/* Logo */}
+			<Link href="/" className="pr-4">
+				<MainLogo />
+			</Link>
 
+			<div className="box-border hidden h-full max-w-2xl flex-1 items-center border-x border-[#424242] px-10 md:flex"></div>
+
+			{/* Navigation */}
+			<ul className="mx-4 hidden items-center gap-6 xl:flex">
+				{mainNavs.map((nav, index) => (
+					// eslint-disable-next-line react/no-array-index-key -- index is unique
+					<li key={index}>
+						<NavLink href={nav.href} color="#969696" activeColor="#A913F9">
+							{nav.title}
+						</NavLink>
+					</li>
+				))}
+			</ul>
 		</CommonHeader>
-	)
+)
 }

--- a/apps/client/src/components/common/molecule/NotificationButton.tsx
+++ b/apps/client/src/components/common/molecule/NotificationButton.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import * as React from "react"
+import { Bell } from '@repo/ui/lucide'
+import { Button } from "@repo/ui/button"
+import { cn } from "@/lib/utils"
+
+interface NotificationButtonProps {
+	count?: number
+	className?: string
+}
+
+export function NotificationButton({ count, className }: NotificationButtonProps) {
+	const displayCount = count && count > 9 ? "9+" : count
+
+	return (
+		<Button
+			variant="ghost"
+			size="icon"
+			className={cn("relative w-[48px] h-[48px]", className)}
+		>
+			<Bell className="w-6 h-6 text-[#C3C3C3]" strokeWidth={2} />
+			{count && count > 0 ? (
+				<span className="absolute right-[10px] top-[10px] flex items-center justify-center min-w-[20px] h-[20px] text-xs font-medium text-white bg-[#A913F9] border-2 border-[#A100F8] rounded-full px-1">
+          {displayCount}
+        </span>
+			) : null}
+		</Button>
+	)
+}

--- a/apps/client/src/components/common/organism/SideBarMenu.tsx
+++ b/apps/client/src/components/common/organism/SideBarMenu.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useState } from "react"
+import { Menu } from "@repo/ui/lucide"
+import { Button } from "@repo/ui/button"
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "@repo/ui/sheet"
+import { useSearchParams } from "next/navigation"
+import SideMenuToggleItem from "@/components/account/molecule/SideMenuToggleItem.tsx"
+import SideMenuItem from "@/components/account/atom/SideMenuItem.tsx"
+import { routes } from "@/config/account/route.ts"
+import { sellerNavs } from "@/lib/navigation.ts"
+
+export function SideBarMenu() {
+	const [open, setOpen] = useState(false)
+	const searchParams = useSearchParams()
+	const viewQuery = searchParams.get("view") ?? ""
+
+	// todo: 유저의 권한에 따라 다른 메뉴를 보여줘야함
+	return (
+		<Sheet open={open} onOpenChange={setOpen}>
+			<SheetTrigger asChild>
+				<Button
+					variant="ghost"
+					className="!h-12 !w-12 rounded-full border-none p-0 hover:!bg-transparent focus-visible:!ring-0 lg:!hidden"
+					onClick={() => setOpen(true)}>
+					<Menu className="!h-7 !w-7 text-white" />
+					<span className="sr-only">Toggle menu</span>
+				</Button>
+			</SheetTrigger>
+			<SheetContent
+				side="left"
+				isClose={false}
+				className="w-[300px] border-r-0 bg-po-black-200 sm:w-[400px]">
+				<SheetHeader className="hidden">
+					<SheetTitle>SideBarMenu</SheetTitle>
+					<SheetDescription>
+						This is a sidebar menu for the users.
+					</SheetDescription>
+				</SheetHeader>
+				<nav className="flex flex-col space-y-4">
+					{sellerNavs.map((item, index) =>
+						item.subMenu ? (
+							<SideMenuToggleItem
+								// eslint-disable-next-line react/no-array-index-key -- This is a static array
+								key={index}
+								view={item.query}
+								label={item.label}
+								activeRoute={viewQuery}
+								Icon={item.icon}
+								subMenu={item.subMenu}
+								subMenuProps={{ onClick: () => setOpen(false) }}
+							/>
+						) : (
+							<SideMenuItem
+								// eslint-disable-next-line react/no-array-index-key -- This is a static array
+								key={index}
+								href={{
+									pathname: routes.account,
+									query: { view: item.query },
+								}}
+								view={item.query}
+								label={item.label}
+								activeRoute={viewQuery}
+								Icon={item.icon}
+								onClick={() => setOpen(false)}
+							/>
+						),
+					)}
+				</nav>
+			</SheetContent>
+		</Sheet>
+	)
+}

--- a/apps/client/src/components/main/molecule/MainHeader.tsx
+++ b/apps/client/src/components/main/molecule/MainHeader.tsx
@@ -4,8 +4,9 @@ import { Button } from "@repo/ui/button"
 import GradientButton from "@/components/common/atom/GradientButton.tsx"
 import Avatar from "@/components/common/atom/Avatar.tsx"
 import MainLogo from "@/components/common/atom/icon/MainLogo.tsx"
-import NavAnchor from "@/components/common/atom/NavAnchor"
+import NavLink from "@/components/common/atom/NavLink"
 import SearchOrganism from "@/components/common/organism/SearchOrganism"
+import { mainNavs } from "@/lib/navigation.ts"
 
 export default function MainHeader() {
 	return (
@@ -24,23 +25,16 @@ export default function MainHeader() {
 				</div>
 
 				{/* Navigation */}
-				<nav className="mx-4 hidden items-center gap-6 xl:flex">
-					<NavAnchor href="/" color="#969696" activeColor="#A913F9">
-						HOME
-					</NavAnchor>
-					<NavAnchor href="/prompts" color="#969696" activeColor="#A913F9">
-						PROMPTS
-					</NavAnchor>
-					<NavAnchor
-						href="/special-exhibition"
-						color="#969696"
-						activeColor="#A913F9">
-						SPECIAL EXHIBITION
-					</NavAnchor>
-					<NavAnchor href="/best" color="#969696" activeColor="#A913F9">
-						BEST
-					</NavAnchor>
-				</nav>
+				<ul className="mx-4 hidden items-center gap-6 xl:flex">
+					{mainNavs.map((nav, index) => (
+						// eslint-disable-next-line react/no-array-index-key -- index is unique
+						<li key={index}>
+							<NavLink href={nav.href} color="#969696" activeColor="#A913F9">
+								{nav.title}
+							</NavLink>
+						</li>
+					))}
+				</ul>
 
 				{/* Right side buttons */}
 				<div className="hidden items-center gap-8 lg:flex">

--- a/apps/client/src/components/main/molecule/MainHeader.tsx
+++ b/apps/client/src/components/main/molecule/MainHeader.tsx
@@ -30,7 +30,7 @@ export default function MainHeader() {
 						// eslint-disable-next-line react/no-array-index-key -- index is unique
 						<li key={index}>
 							<NavLink href={nav.href} color="#969696" activeColor="#A913F9">
-								{nav.title}
+								{nav.label}
 							</NavLink>
 						</li>
 					))}

--- a/apps/client/src/components/main/organism/MainFooter.tsx
+++ b/apps/client/src/components/main/organism/MainFooter.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import Link from "next/link"
-import NavAnchor from "@/components/common/atom/NavAnchor.tsx"
+import NavLink from "@/components/common/atom/NavLink.tsx"
 import FooterLogo from "@/components/common/atom/icon/FooterLogo.tsx"
 import IconLinkContainer from "@/components/main/molecule/IconLinkContainer.tsx"
 import EmailInput from "@/components/common/atom/EmailInput.tsx"
@@ -62,13 +62,13 @@ function MainFooter() {
 										.map((item, i) => (
 											// eslint-disable-next-line react/no-array-index-key -- index is unique
 											<li key={i}>
-												<NavAnchor
+												<NavLink
 													href="#"
 													className="text-sm"
 													activeColor="#FCB808"
 													color="#FFFFFF">
 													{item}
-												</NavAnchor>
+												</NavLink>
 											</li>
 										))}
 								</ul>

--- a/apps/client/src/lib/navigation.ts
+++ b/apps/client/src/lib/navigation.ts
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react"
+
+export interface NavType {
+	title: string
+	href: string
+	icon?: ReactNode
+}
+
+export const mainNavs = [
+	{
+		title: "HOME",
+		href: "/home",
+	},
+	{
+		title: "PROMPTS",
+		href: "/prompts",
+	},
+	{
+		title: "SPECIAL EXHIBITION",
+		href: "/special-exhibition",
+	},
+	{
+		title: "BEST",
+		href: "/best",
+	},
+]

--- a/apps/client/src/lib/navigation.ts
+++ b/apps/client/src/lib/navigation.ts
@@ -5,7 +5,7 @@ export interface NavType {
 	href: string
 	icon?: ReactNode
 }
-
+// todo : href를 고정 문자열이 아니라 route 파일에서 값을 받아오게 수정하기
 export const mainNavs = [
 	{
 		title: "HOME",
@@ -22,5 +22,51 @@ export const mainNavs = [
 	{
 		title: "BEST",
 		href: "/best",
+	},
+]
+
+export const sellerAvatarNavs: NavType[] = [
+	{
+		title: "To Be Seller",
+		href: "/seller-registration",
+	},
+	{
+		title: "Profile",
+		href: "/profile",
+	},
+	{
+		title: "Dashboard",
+		href: "/dashboard",
+	},
+	{
+		title: "Product",
+		href: "/product-list",
+	},
+	{
+		title: "Payouts",
+		href: "/payouts",
+	},
+	{
+		title: "Purchases",
+		href: "/purchases",
+	},
+	{
+		title: "Settings",
+		href: "/settings",
+	},
+]
+
+export const userAvatarNavs: NavType[] = [
+	{
+		title: "Profile",
+		href: "/profile",
+	},
+	{
+		title: "Purchases",
+		href: "/purchases",
+	},
+	{
+		title: "Settings",
+		href: "/settings",
 	},
 ]

--- a/apps/client/src/lib/navigation.ts
+++ b/apps/client/src/lib/navigation.ts
@@ -70,7 +70,7 @@ export const sellerNavs: MenuNavItemType[] = [
 	{
 		icon: Package,
 		label: "Product",
-		href: "account",
+		href: "account?view=product-list",
 		query: "product",
 		subMenu: [
 			{ label: "Create Product", href: "/account", query: "create-product" },

--- a/apps/client/src/lib/navigation.ts
+++ b/apps/client/src/lib/navigation.ts
@@ -1,72 +1,112 @@
-import type { ReactNode } from "react"
+import type { ForwardRefExoticComponent, RefAttributes } from "react"
+import type { LucideProps } from "@repo/ui/lucide"
+import {
+	FileText,
+	Heart,
+	LayoutDashboard,
+	Package,
+	Settings,
+	ShoppingBag,
+	Store,
+	TagsIcon,
+	User,
+	Wallet,
+} from "@repo/ui/lucide"
 
-export interface NavType {
-	title: string
+export type MenuIconType = ForwardRefExoticComponent<
+	Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>
+>
+
+export interface BaseMenuItemType {
+	icon: MenuIconType
+	label: string
 	href: string
-	icon?: ReactNode
+	query: string
 }
+export interface SubMenuItemType extends Omit<BaseMenuItemType, "icon"> {
+	icon?: ForwardRefExoticComponent<
+		Omit<LucideProps, "ref"> & RefAttributes<SVGSVGElement>
+	>
+}
+
+export interface MenuNavItemType extends BaseMenuItemType {
+	subMenu?: SubMenuItemType[]
+}
+
+export interface HeaderNavType
+	extends Omit<BaseMenuItemType, "query" | "icon"> {
+	icon?: MenuIconType
+}
+
 // todo : href를 고정 문자열이 아니라 route 파일에서 값을 받아오게 수정하기
-export const mainNavs = [
+export const mainNavs: HeaderNavType[] = [
 	{
-		title: "HOME",
+		label: "HOME",
 		href: "/home",
 	},
 	{
-		title: "PROMPTS",
+		label: "PROMPTS",
 		href: "/prompts",
 	},
 	{
-		title: "SPECIAL EXHIBITION",
+		label: "SPECIAL EXHIBITION",
 		href: "/special-exhibition",
 	},
 	{
-		title: "BEST",
+		label: "BEST",
 		href: "/best",
 	},
 ]
 
-export const sellerAvatarNavs: NavType[] = [
+// ----------------- Avatar Navs -----------------
+
+export const sellerNavs: MenuNavItemType[] = [
 	{
-		title: "To Be Seller",
-		href: "/seller-registration",
+		icon: LayoutDashboard,
+		label: "Overview",
+		href: "/account",
+		query: "overview",
 	},
 	{
-		title: "Profile",
-		href: "/profile",
+		icon: Package,
+		label: "Product",
+		href: "account",
+		query: "product",
+		subMenu: [
+			{ label: "Create Product", href: "/account", query: "create-product" },
+			{ label: "Product List", href: "/account", query: "product-list" },
+			{ label: "Category", href: "/account", query: "product-category" },
+		],
 	},
+	{ icon: User, label: "Profile", href: "/account", query: "profile" },
+	{ icon: FileText, label: "Prompts", href: "/account", query: "prompts" },
+	{ icon: TagsIcon, label: "Sales", href: "/account", query: "sales" },
+	{ icon: Wallet, label: "Payouts", href: "/account", query: "payouts" },
 	{
-		title: "Dashboard",
-		href: "/dashboard",
+		icon: ShoppingBag,
+		label: "Purchases",
+		href: "/account",
+		query: "purchases",
 	},
-	{
-		title: "Product",
-		href: "/product-list",
-	},
-	{
-		title: "Payouts",
-		href: "/payouts",
-	},
-	{
-		title: "Purchases",
-		href: "/purchases",
-	},
-	{
-		title: "Settings",
-		href: "/settings",
-	},
+	{ icon: Heart, label: "Favorites", href: "/account", query: "favorites" },
+	{ icon: Settings, label: "Settings", href: "/account", query: "settings" },
 ]
 
-export const userAvatarNavs: NavType[] = [
+export const userNavs: MenuNavItemType[] = [
 	{
-		title: "Profile",
-		href: "/profile",
+		label: "To Be Seller",
+		href: "/seller-registration",
+		query: "",
+		icon: Store,
 	},
+	{ icon: User, label: "Profile", href: "/account", query: "profile" },
 	{
-		title: "Purchases",
-		href: "/purchases",
+		icon: ShoppingBag,
+		label: "Purchases",
+		href: "/account",
+		query: "purchases",
 	},
-	{
-		title: "Settings",
-		href: "/settings",
-	},
+	{ icon: Settings, label: "Settings", href: "/account", query: "settings" },
 ]
+
+// ----------------- SideBar Menu Navs -----------------

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,6 @@
 	],
 	"exports": {
 		"./styles.css": "./dist/index.css",
-		"./utils": "./lib/uitls.ts",
 		"./card": "./src/Card.tsx",
 		"./button": "./src/Button.tsx",
 		"./avatar": "./src/Avatar.tsx",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,8 @@
 		"./radio-group": "./src/RadioGroup.tsx",
 		"./rating-read-only": "./src/StarRatingReadOnly.tsx",
 		"./dialog": "./src/Dialog.tsx",
-		"./skeleton": "./src/Skeleton.tsx"
+		"./skeleton": "./src/Skeleton.tsx",
+		"./sheet": "./src/Sheet.tsx"
 	},
 	"license": "MIT",
 	"scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,7 @@
 	],
 	"exports": {
 		"./styles.css": "./dist/index.css",
+		"./utils": "./lib/uitls.ts",
 		"./card": "./src/Card.tsx",
 		"./button": "./src/Button.tsx",
 		"./avatar": "./src/Avatar.tsx",

--- a/packages/ui/src/Lucide.tsx
+++ b/packages/ui/src/Lucide.tsx
@@ -33,5 +33,8 @@ export {
 	UserPlus,
 	UserCheck,
 	Minus,
+	Menu,
+	Receipt,
+	Store,
 	type LucideProps,
 } from "lucide-react"

--- a/packages/ui/src/Lucide.tsx
+++ b/packages/ui/src/Lucide.tsx
@@ -36,5 +36,7 @@ export {
 	Menu,
 	Receipt,
 	Store,
+	MessageSquareText,
+	Bell,
 	type LucideProps,
 } from "lucide-react"

--- a/packages/ui/src/Sheet.tsx
+++ b/packages/ui/src/Sheet.tsx
@@ -20,8 +20,8 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
 	<SheetPrimitive.Overlay
 		className={cn(
-			"fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-			className
+			"fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+			className,
 		)}
 		{...props}
 		ref={ref}
@@ -45,28 +45,31 @@ const sheetVariants = cva(
 		defaultVariants: {
 			side: "right",
 		},
-	}
+	},
 )
 
 interface SheetContentProps
 	extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-		VariantProps<typeof sheetVariants> {}
+		VariantProps<typeof sheetVariants> {
+	isClose?: boolean
+}
 
 const SheetContent = React.forwardRef<
 	React.ElementRef<typeof SheetPrimitive.Content>,
 	SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", isClose = true, className, children, ...props }, ref) => (
 	<SheetPortal>
 		<SheetOverlay />
 		<SheetPrimitive.Content
 			ref={ref}
 			className={cn(sheetVariants({ side }), className)}
-			{...props}
-		>
-			<SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-				<X className="h-4 w-4" />
-				<span className="sr-only">Close</span>
-			</SheetPrimitive.Close>
+			{...props}>
+			{isClose ? (
+				<SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+					<X className="h-4 w-4" />
+					<span className="sr-only">Close</span>
+				</SheetPrimitive.Close>
+			) : null}
 			{children}
 		</SheetPrimitive.Content>
 	</SheetPortal>
@@ -74,30 +77,34 @@ const SheetContent = React.forwardRef<
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 function SheetHeader({
-	                     className,
-	                     ...props
-                     }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div
-		className={cn(
-			"flex flex-col space-y-2 text-center sm:text-left",
-			className
-		)}
-		{...props}
-	/>
+	className,
+	...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+	return (
+		<div
+			className={cn(
+				"flex flex-col space-y-2 text-center sm:text-left",
+				className,
+			)}
+			{...props}
+		/>
+	)
 }
 SheetHeader.displayName = "SheetHeader"
 
 function SheetFooter({
-	                     className,
-	                     ...props
-                     }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div
-		className={cn(
-			"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-			className
-		)}
-		{...props}
-	/>
+	className,
+	...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+	return (
+		<div
+			className={cn(
+				"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+				className,
+			)}
+			{...props}
+		/>
+	)
 }
 SheetFooter.displayName = "SheetFooter"
 

--- a/packages/ui/src/Sheet.tsx
+++ b/packages/ui/src/Sheet.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+import { cn } from "../lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+	React.ElementRef<typeof SheetPrimitive.Overlay>,
+	React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+	<SheetPrimitive.Overlay
+		className={cn(
+			"fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+			className
+		)}
+		{...props}
+		ref={ref}
+	/>
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+	"fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+	{
+		variants: {
+			side: {
+				top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+				bottom:
+					"inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+				left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+				right:
+					"inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+			},
+		},
+		defaultVariants: {
+			side: "right",
+		},
+	}
+)
+
+interface SheetContentProps
+	extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+		VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+	React.ElementRef<typeof SheetPrimitive.Content>,
+	SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+	<SheetPortal>
+		<SheetOverlay />
+		<SheetPrimitive.Content
+			ref={ref}
+			className={cn(sheetVariants({ side }), className)}
+			{...props}
+		>
+			<SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+				<X className="h-4 w-4" />
+				<span className="sr-only">Close</span>
+			</SheetPrimitive.Close>
+			{children}
+		</SheetPrimitive.Content>
+	</SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+function SheetHeader({
+	                     className,
+	                     ...props
+                     }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div
+		className={cn(
+			"flex flex-col space-y-2 text-center sm:text-left",
+			className
+		)}
+		{...props}
+	/>
+}
+SheetHeader.displayName = "SheetHeader"
+
+function SheetFooter({
+	                     className,
+	                     ...props
+                     }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div
+		className={cn(
+			"flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+			className
+		)}
+		{...props}
+	/>
+}
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+	React.ElementRef<typeof SheetPrimitive.Title>,
+	React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+	<SheetPrimitive.Title
+		ref={ref}
+		className={cn("text-lg font-semibold text-foreground", className)}
+		{...props}
+	/>
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+	React.ElementRef<typeof SheetPrimitive.Description>,
+	React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+	<SheetPrimitive.Description
+		ref={ref}
+		className={cn("text-sm text-muted-foreground", className)}
+		{...props}
+	/>
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+	Sheet,
+	SheetPortal,
+	SheetOverlay,
+	SheetTrigger,
+	SheetClose,
+	SheetContent,
+	SheetHeader,
+	SheetFooter,
+	SheetTitle,
+	SheetDescription,
+}


### PR DESCRIPTION
# 변경사항
- 공통으로 사용될 부분을  components/common/atom에 Header 컴포넌트 추가 
- components/common 디렉토리에 반응형 개선 및 추가 컴포넌트를 추가한 MainHeader 컴포넌트 추가 
- NavAnchor 컴포넌트의 이름을 NavLink로 수정 
- navigation과 관련된 데이터와 타입을 lib/navigation.ts에 정의 
- Shadcn/ui Sheet 컴포넌트 추가 
- 내비게이션 드롭다운을 보여주는 AvatarMenu 컴포넌트 추가 

# Todo
- 검색 다이얼로그 컴포넌트 추가 필요 - 모바일 또는 태블릿인 경우 검색 아이콘으로 바뀌는 반응형 작업도 필요함
- BadgeContainer로만 표현된 컴포넌트 중, 알림과 관련된 모달을 띄우고 메시지와 카트는 해당 페이지로 이동해야한다. 
   그 이후에 새로운 wrapper 컴포넌트로 정의하기
- 내비게이션 정보는 유저의 권한에 따라 다른 메뉴를 보여줘야함 --> auth에서 유저인지 판매자인지에 따라 내비게이션 정보 분기하여 보여주기