### PR TITLE
JYXB-370-FE-S3-S3-Problem-Improvement

### DIFF
--- a/apps/client/src/components/profile-modify/atoms/ProfileModifyName.tsx
+++ b/apps/client/src/components/profile-modify/atoms/ProfileModifyName.tsx
@@ -1,6 +1,6 @@
 interface MemberNameProps {
 	hashTag: string | undefined
-	nickname: string
+	nickname: string | undefined
 	email: string | undefined
 	joined: string
 }

--- a/apps/client/src/components/profile-modify/molecules/ProfileModifyInfoLeft.tsx
+++ b/apps/client/src/components/profile-modify/molecules/ProfileModifyInfoLeft.tsx
@@ -5,7 +5,7 @@ import ProfileModifyName from "../atoms/ProfileModifyName"
 
 interface MemberLeftProps {
 	hashTag: string | undefined
-	nickname: string
+	nickname: string | undefined
 	email: string | undefined
 	joined: string
 }

--- a/apps/client/src/components/profile-modify/organisms/ProfileModifyInfo.tsx
+++ b/apps/client/src/components/profile-modify/organisms/ProfileModifyInfo.tsx
@@ -56,12 +56,12 @@ export default function ProfileModifyInfo({ memberData }: MemberDataProps) {
 		if (!isAvatarUploaded) return
 
 		const payload: CommonModifyType = {
-			memberUUID: "test",
-			bannerImageUrl: formData.get("bannerImageUrl") as string | undefined,
-			avatarImageUrl: formData.get("avatarImageUrl") as string | undefined,
+			memberUUID: "test" as string,
+			bannerImageUrl: formData.get("bannerImageUrl") as string,
+			avatarImageUrl: formData.get("avatarImageUrl") as string,
 			hashTag: formData.get("hashTag") as string,
 			bio: formData.get("bio") as string,
-			email: formData.get("email") as string | undefined,
+			email: formData.get("email") as string,
 			nickname: formData.get("nickname") as string,
 		}
 

--- a/apps/client/src/hooks/modify/useModify.ts
+++ b/apps/client/src/hooks/modify/useModify.ts
@@ -2,24 +2,30 @@ import { useState } from "react"
 import { uploadImage } from "@/action/s3/s3UploadAction"
 import type { CommonModifyType } from "@/types/modify/commonModifyTypes"
 
-export const useModify = (memberData: CommonModifyType) => {
+export const useModify = (modifyData: CommonModifyType) => {
 	//// 변수 관리 START ////
 	const [banner, setBanner] = useState<string | undefined>(
-		memberData.bannerImageUrl ? memberData.bannerImageUrl : "",
+		modifyData.bannerImageUrl ? modifyData.bannerImageUrl : "",
 	)
+
 	const [avatar, setAvatar] = useState<string | undefined>(
-		memberData.avatarImageUrl ? memberData.avatarImageUrl : "",
+		modifyData.avatarImageUrl ? modifyData.avatarImageUrl : "",
 	)
 
 	const [hashTag, setHashTag] = useState<string | undefined>(
-		memberData.hashTag ? memberData.hashTag : "",
+		modifyData.hashTag ? modifyData.hashTag : "",
 	)
-	const [nickname, setNickname] = useState<string>(memberData.nickname)
+
+	const [nickname, setNickname] = useState<string | undefined>(
+		modifyData.nickname ? modifyData.nickname : "",
+	)
+
 	const [email, setEmail] = useState<string | undefined>(
-		memberData.email ? memberData.email : "",
+		modifyData.email ? modifyData.email : "",
 	)
+
 	const [bio, setBio] = useState<string | undefined>(
-		memberData.bio ? memberData.bio : "",
+		modifyData.bio ? modifyData.bio : "",
 	)
 	//// 변수 관리 END ////
 
@@ -82,22 +88,22 @@ export const useModify = (memberData: CommonModifyType) => {
 	const handleReset = (field: string) => {
 		switch (field) {
 			case "banner":
-				setBanner(memberData.bannerImageUrl ? memberData.bannerImageUrl : "")
+				setBanner(modifyData.bannerImageUrl ? modifyData.bannerImageUrl : "")
 				break
 			case "avatar":
-				setAvatar(memberData.avatarImageUrl ? memberData.avatarImageUrl : "")
+				setAvatar(modifyData.avatarImageUrl ? modifyData.avatarImageUrl : "")
 				break
 			case "hashTag":
-				setHashTag(memberData.hashTag ? memberData.hashTag : "")
+				setHashTag(modifyData.hashTag ? modifyData.hashTag : "")
 				break
 			case "nickname":
-				setNickname(memberData.nickname)
+				setNickname(modifyData.nickname ? modifyData.nickname : "")
 				break
 			case "email":
-				setEmail(memberData.email ? memberData.email : "")
+				setEmail(modifyData.email ? modifyData.email : "")
 				break
 			case "bio":
-				setBio(memberData.bio ? memberData.bio : "")
+				setBio(modifyData.bio ? modifyData.bio : "")
 				break
 			default:
 				break

--- a/apps/client/src/types/modify/commonModifyTypes.ts
+++ b/apps/client/src/types/modify/commonModifyTypes.ts
@@ -1,9 +1,9 @@
 export interface CommonModifyType {
-	memberUUID: string
+	memberUUID?: string | undefined
 	bannerImageUrl?: string | undefined
 	avatarImageUrl?: string | undefined
 	hashTag?: string | undefined
 	bio?: string | undefined
 	email?: string | undefined
-	nickname: string
+	nickname?: string | undefined
 }


### PR DESCRIPTION
KR : S3의 공통 기능화 작업 중 생긴 문제 해결 - S3 CommonType의 옵셔널화 진행
EN : Troubleshooting the Common Functionalization of S3 - Proceeding with the Optionalization of S3 CommonType

---------------------------------

```
**[CommonType의 옵셔널화]**
export interface CommonModifyType {
	memberUUID?: string | undefined
	bannerImageUrl?: string | undefined
	avatarImageUrl?: string | undefined
	hashTag?: string | undefined
	bio?: string | undefined
	email?: string | undefined
	nickname?: string | undefined
}
```

---------------------------------

```
**[받는 변수 명 변경]**
변경 : export const useModify = (modifyData: CommonModifyType)
기존 : export const useModify = (memberData: CommonModifyType)
```

---------------------------------

```
**[모든 상태 관리 변수 string | undefined 타입으로 변경 및,  기본 값의 분기 처리]**
const [banner, setBanner] = useState<string | undefined>(
	modifyData.bannerImageUrl ? modifyData.bannerImageUrl : "",
)
```

---------------------------------

```
**[payload의 타입은 String으로 + 필요한 데이터만 사용 -> 옵셔널화를 통해 해결]**
const payload: CommonModifyType = {
	memberUUID: "test" as string,
	bannerImageUrl: formData.get("bannerImageUrl") as string,
	avatarImageUrl: formData.get("avatarImageUrl") as string,
	hashTag: formData.get("hashTag") as string,
	bio: formData.get("bio") as string,
	email: formData.get("email") as string,
	nickname: formData.get("nickname") as string,
}
```

---------------------------------

```
**[수정되는 부분의 데이터를 내려받는 하위 컴포넌트는 값이 있더라도 undefined를 추가로 지정해주어야 함]**
interface MemberLeftProps {
	hashTag: string | undefined
	nickname: string | undefined
	email: string | undefined
	joined: string
}
```
