### PR TITLE
Fix: CD 과정에서 SSH 연결 시간 제한 1분에서 대폭 확대

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -34,7 +34,7 @@ jobs:
           host: ${{ secrets.EC2_FE_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
-          timeout: 60s
+          timeout: 1800s
           script: |
             echo "Stopping existing container..."
             sudo docker stop prompt_oven_fe || true


### PR DESCRIPTION
도커 이미지 다운이 오래 걸리더라구요