### PR TITLE
Fix: update ssh action version 0.1.6 -> 1^

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -29,7 +29,7 @@ jobs:
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/prompt_oven_fe:latest
       
       - name: Deploy to EC2
-        uses: appleboy/ssh-action@v0.1.6
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.EC2_FE_HOST }}
           username: ubuntu
@@ -44,7 +44,7 @@ jobs:
             sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/prompt_oven_fe:latest
             
             echo "Running container..."
-            sudo docker run -d --name prompt_oven_fe -p 3000:3000 -p 3001:3001 ${{ secrets.DOCKERHUB_USERNAME }}/prompt_oven_fe:latest
+            sudo docker-compose up -d
             
             echo "Cleaning up unused Docker images..."
             sudo docker image prune -f 


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/CD.yml` file to update the deployment process. The most important changes include updating the SSH action version and switching from using `docker run` to `docker-compose` for running the container.

Updates to deployment process:

* [`.github/workflows/CD.yml`](diffhunk://#diff-a64cbb6e953e697cb4302ab31af9ebbd95a8de6216f874bb0ffdefce8e3c1cd9L32-R32): Updated the SSH action from version `v0.1.6` to `v1` for deploying to EC2.

* [`.github/workflows/CD.yml`](diffhunk://#diff-a64cbb6e953e697cb4302ab31af9ebbd95a8de6216f874bb0ffdefce8e3c1cd9L47-R47): Replaced `sudo docker run` command with `sudo docker-compose up -d` to run the container.

```yaml
services:
  prompt_oven_fe:
    image: astar5327/prompt_oven_fe:latest
    container_name: prompt_oven_fe
    ports:
      - "3000:3000"
      - "3001:3001"