### PR TITLE
🐛 Fix: JYXB-417 Profile revalidation

### DIFF
--- a/apps/client/src/action/profile/getProfileData.ts
+++ b/apps/client/src/action/profile/getProfileData.ts
@@ -12,7 +12,10 @@ export async function getProfileMemberInfo(id: string): Promise<ProfileMemberInf
 	const res = await fetch(`${process.env.API_BASE_URL}/v1/profile/nickname/${id}`, {
 		method: "GET",
 		headers,
-		next: { revalidate: 3600 },
+		next: { 
+			revalidate: 3600,
+			tags: ['profile']
+		},
 	})
 	void fetch(`${process.env.API_BASE_URL}/v1/profile/viewership/nickname/${id}`, {
 		method: "POST",
@@ -37,7 +40,10 @@ export async function getProfileMemberInfoByUuid(id: string): Promise<ProfileMem
 	const res = await fetch(`${process.env.API_BASE_URL}/v1/profile/uuid/${id}`, {
 		method: "GET",
 		headers,
-		next: { revalidate: 3600 },
+		next: { 
+			revalidate: 3600,
+			tags: ['profile']
+		},
 	})
 	void fetch(`${process.env.API_BASE_URL}/v1/profile/viewership/uuid/${id}`, {
 		method: "POST",

--- a/apps/client/src/action/profile/modifyProfileData.ts
+++ b/apps/client/src/action/profile/modifyProfileData.ts
@@ -1,6 +1,6 @@
 "use server"
 
-import { revalidatePath } from "next/cache"
+import { revalidatePath, revalidateTag } from "next/cache"
 import type { ProfileModifyType } from "@/types/profile/profileTypes"
 import { initializeHeaders } from "@/lib/api/headers"
 import { getAccessToken } from "@/lib/api/sessionExtractor"
@@ -18,6 +18,8 @@ export async function modifyProfileData(data: ProfileModifyType) {
 		throw new Error('Failed to modify profile data')
 	}
 	// this will revalidate the profile page
+	revalidateTag('profile')
 	revalidatePath(`/profile/${data.nickname}`)
+	revalidatePath(`/profile/modify/${data.memberUUID}`)
 
 }


### PR DESCRIPTION
This pull request includes several changes aimed at improving the profile data handling and revalidation logic in the client application. The most important changes are grouped by theme below:

### Revalidation Enhancements:
* Added `tags: ['profile']` to the `next` revalidation options in `getProfileMemberInfo` and `getProfileMemberInfoByUuid` functions to better manage cache revalidation. [[1]](diffhunk://#diff-28804972e360c031c41b3904126cab837baf6c509d7f4d7afd899d397eb05419L15-R18) [[2]](diffhunk://#diff-28804972e360c031c41b3904126cab837baf6c509d7f4d7afd899d397eb05419L40-R46)
* Updated `modifyProfileData` function to include `revalidateTag('profile')` and additional revalidation paths to ensure the profile data is accurately updated.

### Code Improvements:
* Replaced `redirect` with `useRouter` in `ProfileModifyInfo` component to handle navigation and client-side cache refresh more effectively. [[1]](diffhunk://#diff-919f6f446987d2bd0e740d29d69687d6da43a8ac4086adb6dd290730cb2aa158L4-R4) [[2]](diffhunk://#diff-919f6f446987d2bd0e740d29d69687d6da43a8ac4086adb6dd290730cb2aa158R75-R85)
* Added a brief delay after nickname change in `ProfileModifyInfo` to allow for revalidation before navigating to the updated profile page.

### Import Adjustments:
* Imported `revalidateTag` from `next/cache` in `modifyProfileData` to support the new revalidation logic.
* Updated import statement in `ProfileModifyInfo` to use `useRouter` instead of `redirect`.