### PR TITLE
🐛 Fix: Api response null handling

### DIFF
--- a/apps/client/src/app/api/auth/[...nextauth]/authOption.ts
+++ b/apps/client/src/app/api/auth/[...nextauth]/authOption.ts
@@ -40,7 +40,7 @@ export const authOptions: NextAuthOptions = {
                     nickname: response.result.nickname,
                     memberUUID: response.result.memberUUID,
                     role: response.result.role,
-                    profileImage: profileImage.picture,
+                    profileImage: profileImage.picture || "",
                     failed: false,
                 };
             },
@@ -125,8 +125,8 @@ export const authOptions: NextAuthOptions = {
                 const refreshedToken = await refreshAccessToken(token.refreshtoken as string || "")
                 if (refreshedToken.result) {
                   const profileImage = await getProfileImage(user.memberUUID)
-                  token.profileImage = profileImage.picture
-                  user.profileImage = profileImage.picture
+                  token.profileImage = profileImage.picture || ""
+                  user.profileImage = profileImage.picture || ""
 
                   token.accesstoken = refreshedToken.result.accessToken;
                   user.accesstoken = refreshedToken.result.accessToken

--- a/apps/client/src/components/profile/organisms/ProfileMemberInfo.tsx
+++ b/apps/client/src/components/profile/organisms/ProfileMemberInfo.tsx
@@ -4,16 +4,21 @@ import ProfileBanner from "../atoms/info/ProfileBanner"
 import ProfileInfoLeft from "../molecules/ProfileInfoLeft"
 import ProfileInfoRight from "../molecules/ProfileInfoRight"
 
+// todo: 공용 이미지 컴포넌트 파일로 따로 빼내기
+const DEFAULT_BANNER = "https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/ProfileBanner.png"
+const DEFAULT_AVATAR = "https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/TestAvartar.png"
+
 interface MemberDataProps {
 	memberData: ProfileMemberInfoType
 }
 
 export default function ProfileMemberInfo({ memberData }: MemberDataProps) {
+
 	return (
 		<div className="mx-2">
-			<ProfileBanner memberBanner={!memberData.bannerImageUrl || memberData.bannerImageUrl === "" ? "https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/ProfileBanner.png" : memberData.bannerImageUrl} />
+			<ProfileBanner memberBanner={!memberData.bannerImageUrl || memberData.bannerImageUrl === "" ? DEFAULT_BANNER : memberData.bannerImageUrl} />
 			<div className="relative -top-[3.5rem] z-[5] mx-10 flex flex-col gap-4 md:-top-[5.5rem] md:h-40 md:!flex-row md:items-center md:justify-between xl:h-44">
-				<ProfileAvatar memberAvatar={!memberData.avatarImageUrl || memberData.avatarImageUrl === "" ? "https://promptoven.s3.ap-northeast-2.amazonaws.com/dummy/profile/TestAvartar.png" : memberData.avatarImageUrl} />
+				<ProfileAvatar memberAvatar={!memberData.avatarImageUrl || memberData.avatarImageUrl === "" ? DEFAULT_AVATAR : memberData.avatarImageUrl} />
 
 				<div className="flex flex-grow justify-between gap-2 rounded-xl bg-gradient-to-r from-[#B514F1] to-[#0BA9FF] p-4 md:h-[90%] md:items-center">
 					<ProfileInfoLeft memberData={memberData} />

--- a/apps/client/src/types/profile/profileTypes.ts
+++ b/apps/client/src/types/profile/profileTypes.ts
@@ -9,7 +9,7 @@ export const PROFILE_FIELDS = {
 
 export interface ProfileImageType {
 	memberUUID: string
-	picture: string
+	picture: string | undefined
 }
 
 // Base type with all shared fields


### PR DESCRIPTION
This pull request includes changes to improve the handling of profile images and refactor the code for better maintainability. The most important changes include adding default values for profile images, refactoring the profile image URL handling, and updating type definitions.

Improvements to profile image handling:

* `apps/client/src/app/api/auth/[...nextauth]/authOption.ts`: Added a default empty string for `profileImage` if `profileImage.picture` is undefined or null. ([apps/client/src/app/api/auth/[...nextauth]/authOption.tsL43-R43](diffhunk://#diff-83092db29e5e0a4bbae9d0e63318697ecb8f1046a9cb1967f82b6f20f7f94628L43-R43), [apps/client/src/app/api/auth/[...nextauth]/authOption.tsL128-R129](diffhunk://#diff-83092db29e5e0a4bbae9d0e63318697ecb8f1046a9cb1967f82b6f20f7f94628L128-R129))

Code refactoring:

* [`apps/client/src/components/profile/organisms/ProfileMemberInfo.tsx`](diffhunk://#diff-772f694ae2965ae8e59c2a40c4fcc9ea15ccc8ecb75ba8eb288987599670fe6cR7-R21): Introduced constants `DEFAULT_BANNER` and `DEFAULT_AVATAR` for default image URLs and used them to simplify the logic for setting `ProfileBanner` and `ProfileAvatar`.

Type definition updates:

* [`apps/client/src/types/profile/profileTypes.ts`](diffhunk://#diff-188b051e65cac402fa7f451f44141c9a0138aac77573fc26bf00dbaab89393ceL12-R12): Updated the `ProfileImageType` interface to allow `picture` to be either a string or undefined.