### PR TITLE
Featrue/refresh session after profile edit

### DIFF
--- a/apps/client/src/components/profile-modify/organisms/ProfileModifyInfo.tsx
+++ b/apps/client/src/components/profile-modify/organisms/ProfileModifyInfo.tsx
@@ -7,6 +7,7 @@ import { useModify } from "@/hooks/modify/useModify"
 import type { ProfileModifyType, ProfileMemberInfoType } from "@/types/profile/profileTypes"
 import { modifyProfileData } from "@/action/profile/modifyProfileData"
 import { formatDate } from "@/lib/utils"
+import { refreshAccessTokenAfterRoleChange } from "@/action/auth/refreshAfterRoleChangeAction"
 import ProfileModifyAvatar from "../molecules/ProfileModifyAvatar"
 import ProfileModifyBanner from "../molecules/ProfileModifyBanner"
 import ProfileModifyInfoLeft from "../molecules/ProfileModifyInfoLeft"
@@ -91,6 +92,7 @@ export default function ProfileModifyInfo({ memberData }: MemberDataProps) {
 			await new Promise(resolve => {
 				setTimeout(resolve, 1000)
 			})
+			await refreshAccessTokenAfterRoleChange();
 		}
 
 		router.refresh(); // Force client-side cache refresh

--- a/packages/ui/src/Calendar.tsx
+++ b/packages/ui/src/Calendar.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable  -- 임시방편 */
-
 "use client"
 
 import * as React from "react"

--- a/packages/ui/src/PopOver.tsx
+++ b/packages/ui/src/PopOver.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable  -- 임시방편 */
-
 "use client"
 
 import * as React from "react"


### PR DESCRIPTION
This pull request includes changes to the `ProfileModifyInfo` component and cleanup of ESLint disable comments in the `Calendar` and `PopOver` components. The most important changes include adding a new import for refreshing the access token after a role change and invoking this function in the profile modification logic.

Changes to `ProfileModifyInfo` component:

* [`apps/client/src/components/profile-modify/organisms/ProfileModifyInfo.tsx`](diffhunk://#diff-919f6f446987d2bd0e740d29d69687d6da43a8ac4086adb6dd290730cb2aa158R10): Added import for `refreshAccessTokenAfterRoleChange` from `@/action/auth/refreshAfterRoleChangeAction`.
* [`apps/client/src/components/profile-modify/organisms/ProfileModifyInfo.tsx`](diffhunk://#diff-919f6f446987d2bd0e740d29d69687d6da43a8ac4086adb6dd290730cb2aa158R95): Invoked `refreshAccessTokenAfterRoleChange` after a role change in the `ProfileModifyInfo` function.

Code cleanup:

* [`packages/ui/src/Calendar.tsx`](diffhunk://#diff-268bbf0d341cf70ebd9d47da702648bda2192ab31e5aa1a6360061e8007d652dL1-L2): Removed unnecessary ESLint disable comments.
* [`packages/ui/src/PopOver.tsx`](diffhunk://#diff-820c2ccb82798fb87739ccf8716cad25271fa67a255103e9b2211d5d42c34654L1-L2): Removed unnecessary ESLint disable comments.