### PR TITLE
hotfix: 상대방과 채팅 시작하기 버튼 로딩 추가

### DIFF
--- a/apps/client/src/components/chat/organism/ChatSidebar.tsx
+++ b/apps/client/src/components/chat/organism/ChatSidebar.tsx
@@ -167,7 +167,7 @@ export function ChatSidebar({
 					</div>
 				) : filteredChatRooms.length === 0 ? (
 					<div className="flex h-full items-center justify-center">
-						<p className="text-[#E2ADFF]">No chat rooms found</p>
+						<p className="text-[#E2ADFF]">채팅방이 없습니다</p>
 					</div>
 				) : (
 					filteredChatRooms.map((room) => (

--- a/apps/client/src/components/common/atom/LoadingButton.tsx
+++ b/apps/client/src/components/common/atom/LoadingButton.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from "react"
+import { Button } from "@repo/ui/button"
+import { ThreeDots } from "react-loader-spinner"
+import type { ButtonProps } from "@/components/seller/atom/RsButton.tsx"
+import { delay } from "@/lib/utils.ts"
+
+interface LoadingButtonProps extends ButtonProps {
+	children?: React.ReactNode
+	isLoading?: boolean
+	onClick?: () => Promise<void> | void
+	isAsync?: boolean
+}
+
+function LoadingButton({
+	children,
+	isLoading: externalLoading,
+	isAsync = false,
+	onClick,
+	...props
+}: LoadingButtonProps) {
+	const [internalLoading, setInternalLoading] = useState(false)
+	const isLoading = externalLoading || internalLoading
+
+	const handleClick = async () => {
+		if (onClick && isAsync) {
+			setInternalLoading(true)
+			try {
+				await onClick()
+				await delay(1000)
+			} finally {
+				setInternalLoading(false)
+			}
+		} else if (onClick && !isAsync) {
+			onClick()
+		}
+	}
+
+	return (
+		<Button
+			type="button"
+			{...props}
+			onClick={handleClick}
+			disabled={isLoading || props.disabled}>
+			{isLoading ? (
+				<ThreeDots
+					visible
+					width="100"
+					height="80"
+					radius="9"
+					color="#ffffff"
+					ariaLabel="three-dots-loading"
+					wrapperStyle={{}}
+					wrapperClass=""
+				/>
+			) : (
+				children
+			)}
+		</Button>
+	)
+}
+
+export default LoadingButton

--- a/apps/client/src/components/profile-seller/atoms/ChattingButton.tsx
+++ b/apps/client/src/components/profile-seller/atoms/ChattingButton.tsx
@@ -2,7 +2,8 @@
 
 import { useRouter } from "next/navigation"
 import { startTalkWith } from "@/action/chat/chatAction.ts"
-import GradientButton from "@/components/common/atom/GradientButton.tsx"
+import LoadingButton from "@/components/common/atom/LoadingButton.tsx"
+import { cn } from "@/lib/utils.ts"
 
 interface ChattingButtonProps {
 	sellerUuid: string
@@ -21,14 +22,25 @@ export default function ChattingButton({
 
 	return (
 		<section>
-			<GradientButton
+			<LoadingButton
 				type="button"
-				className="h-[40px] w-[100px] px-[20px] py-[10px]"
+				className={cn(
+					"h-[40px] w-[100px] px-[20px] py-[10px]",
+					"text-center text-white",
+					"font-sora text-[15px] font-semibold leading-[20px]",
+					"rounded-[10px]",
+					"transition-all duration-300 ease-in-out",
+					"hover:opacity-90",
+					"focus:ring-2 focus:ring-purple-400 focus:ring-opacity-50",
+					"disabled:opacity-50",
+					"bg-gradient-to-r from-[#A913F9] to-[#9D3D81]", // gradient 값
+				)}
+				isAsync
 				onClick={() => {
 					chatWithPeople(sellerUuid).then()
 				}}>
 				대화하기
-			</GradientButton>
+			</LoadingButton>
 		</section>
 	)
 }


### PR DESCRIPTION
This pull request includes changes to the chat and button components in the client application. The most important changes involve the addition of a new `LoadingButton` component, the replacement of the `GradientButton` with `LoadingButton` in the `ChattingButton` component, and a text update in the `ChatSidebar` component.

### New Component Addition:
* [`apps/client/src/components/common/atom/LoadingButton.tsx`](diffhunk://#diff-2c0bc38afe1fa8cf20d0ed1f4f8459dd1e7c3eef8d641f6c771e25239c1d31baR1-R62): Added a new `LoadingButton` component that supports asynchronous operations and displays a loading spinner.

### Component Updates:
* [`apps/client/src/components/profile-seller/atoms/ChattingButton.tsx`](diffhunk://#diff-2947b2a64d77da04d4b23ed401d310527be6b72d321d6f48dc053e17b6a1c721L5-R6): Replaced `GradientButton` with the new `LoadingButton` component to handle asynchronous chat initiation with loading state. Updated the button's class names for styling. [[1]](diffhunk://#diff-2947b2a64d77da04d4b23ed401d310527be6b72d321d6f48dc053e17b6a1c721L5-R6) [[2]](diffhunk://#diff-2947b2a64d77da04d4b23ed401d310527be6b72d321d6f48dc053e17b6a1c721L24-R43)

### Text Update:
* [`apps/client/src/components/chat/organism/ChatSidebar.tsx`](diffhunk://#diff-338bca5767fbcd670f8881b958bdee5daed2edaa7b3a1b32da61fd90a2e4fd74L170-R170): Updated the text displayed when no chat rooms are found to "채팅방이 없습니다" to support localization.